### PR TITLE
Adjust column names in the QL timeseries

### DIFF
--- a/stixpy/timeseries/quicklook.py
+++ b/stixpy/timeseries/quicklook.py
@@ -98,7 +98,7 @@ class QLLightCurve(GenericTimeSeries):
 
         dates = matplotlib.dates.date2num(self.to_dataframe().index)
 
-        labels = [f'{col} keV' for col in self.columns[5:]]
+        labels = [f'{col}' for col in self.columns[5:]]
 
         lines = [axes.plot_date(dates, self.to_dataframe().iloc[:, 5+i], '-', label=labels[i], **plot_args)
          for i in range(5)]
@@ -156,7 +156,7 @@ class QLLightCurve(GenericTimeSeries):
 
         data['counts'] = data['counts'] / (live_time.reshape(-1, 1) * energy_delta)
 
-        names = [f'{energies["e_low"][i]}-{energies["e_high"][i]}' for i in range(5)]
+        names = ['{:d}-{:d} keV'.format(energies["e_low"][i].astype(int),energies["e_high"][i].astype(int)) for i in range(5)]
 
         [data.add_column(data['counts'][:, i], name=names[i]) for i in range(5)]
         data.remove_column('counts')


### PR DESCRIPTION
This is a PR to label the columns in `QLLightCurve` to be `4-10 keV` rather than `4.0-10.0`. The motivation behind this is that this is now similar to how the columns are named in both the `GBMSummaryTimeSeries` and `RHESSISummaryTimeSeries`.

For example now:

```python
>>> ql_lightcurve.columns[5:10]
['4-10 keV', '10-15 keV', '15-25 keV', '25-50 keV', '50-84 keV']
```

whereas before 
```python
>>> ql_lightcurve.columns[5:10]
['4.0-10.0', '10.0-15.0', '15.0-25.0', '25.0-50.0', '50.0-84.0']
```
which are not as intuitive to index.