### PR TITLE
Add function to parse time inputs to indices

### DIFF
--- a/stixpy/timeseries/quicklook.py
+++ b/stixpy/timeseries/quicklook.py
@@ -556,7 +556,7 @@ class QLVariance(GenericTimeSeries):
 
 class HKMaxi(GenericTimeSeries):
     """
-    House Keeping Maxi Report.
+    Housekeeping Maxi Report.
 
     Examples
     --------

--- a/stixpy/utils/tests/test_time.py
+++ b/stixpy/utils/tests/test_time.py
@@ -36,7 +36,11 @@ def test_times_to_indices_1d_times():
 def test_times_to_indices_2d_times():
     observed_times = Time.now() + np.arange(10) * 10 * u.s
     tmp = np.arange(10)*10
+    requested_times = (observed_times[0]+[0, 90]*u.s).reshape(2, 1)
+    indices = times_to_indices(requested_times, observed_times)
+    assert_equal(indices, np.array([[0, 9]]))
     requested_times = observed_times[0] + np.vstack((tmp[0:-1], tmp[1:]))*u.s
+
     indices = times_to_indices(requested_times, observed_times)
     assert_equal(indices,  np.array([[0, 1], [1, 2], [2, 3], [3, 4], [4, 5],
                                   [5, 6], [6, 7], [7, 8], [8, 9]]))

--- a/stixpy/utils/tests/test_time.py
+++ b/stixpy/utils/tests/test_time.py
@@ -1,0 +1,45 @@
+
+import pytest
+import astropy.units as u
+import numpy as np
+
+from astropy.time import Time
+from numpy.testing import assert_equal
+
+from stixpy.utils.time import times_to_indices
+
+@pytest.mark.parametrize('duration,expected_indices', [(5*u.s,  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+                                                       (10*u.s, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+                                                       (15*u.s, [0, 1, 3, 4, 6, 7, 9]),
+                                                       (20*u.s, [0, 2, 4, 6, 8, 9]),
+                                                       (200*u.s, [0,9])])
+def test_times_to_indices_scalar(duration, expected_indices):
+    observed_times = Time('2021-12-20T00:00:00.0') + np.arange(10) * 10*u.s
+    indices = times_to_indices(duration, observed_times)
+    assert_equal(indices, np.array(expected_indices))
+
+def test_times_to_indices_1d_times():
+    observed_times = Time.now() + np.arange(10) * 10 * u.s
+    request_times = observed_times[:]
+    indices = times_to_indices(request_times, observed_times)
+    assert_equal(indices, np.arange(10))
+    indices1 = times_to_indices(request_times - 5.0 * u.s, observed_times)
+    assert_equal(indices1, np.arange(9))
+    indices2 = times_to_indices(request_times + 5 * u.s, observed_times)
+    assert_equal(indices2, np.arange(10))
+
+    uneven_obs_time = observed_times[0] + [5,  15,  30,  50,  70,  85,  95, 100] * u.s
+    request_times = observed_times[0] + np.cumsum(np.arange(8)*10) * u.s
+    indices3 = times_to_indices(request_times, uneven_obs_time)
+    assert_equal(indices3, [0, 2, 3, 7])
+
+def test_times_to_indices_2d_times():
+    observed_times = Time.now() + np.arange(10) * 10 * u.s
+    tmp = np.arange(10)*10
+    requested_times = observed_times[0] + np.vstack((tmp[0:-1], tmp[1:]))*u.s
+    indices = times_to_indices(requested_times, observed_times)
+    assert_equal(indices,  np.array([[0, 1], [1, 2], [2, 3], [3, 4], [4, 5],
+                                  [5, 6], [6, 7], [7, 8], [8, 9]]))
+    requested_times = observed_times[0] + [[0, 18], [18, 27], [27, 30], [30, 50], [50, 62],[62, 110]]*u.s
+    indices2 = times_to_indices(requested_times, observed_times)
+    assert_equal(indices2, np.array([[0, 2], [2, 3], [3, 3], [3, 5], [5, 6], [6, 9]]))

--- a/stixpy/utils/time.py
+++ b/stixpy/utils/time.py
@@ -1,0 +1,82 @@
+import astropy.units as u
+import numpy as np
+
+from astropy.time import Time, TimeDelta
+from numpy.testing import assert_equal
+
+
+def times_to_indices(in_times, obs_times, unit=u.ms, decimals=3):
+    """
+    Convert the input time/s to indices.
+
+    Parameters
+    ----------
+    in_times : `astropy.units.Quantity`
+        A target duration e.g `5*u.s` an array of `Time` if 2d
+    obs_times : `astropy.units.Quantity`
+
+    Returns
+    -------
+    Array of indices
+    """
+    unique_only = False
+    shape = None
+    relative_times = np.around((obs_times - obs_times[0]).to(unit), decimals=decimals)
+
+    if in_times.isscalar:
+        interval = in_times
+        total_duration = obs_times[-1] - obs_times[0]
+        if interval < total_duration:
+            num_intervals = np.ceil((total_duration / interval).decompose()) + 1
+            target_times = np.around((np.arange(num_intervals) * interval).to(unit),
+                                     decimals=decimals)
+            unique_only = True
+        else:
+            target_times = relative_times[[0,-1]]
+    elif isinstance(in_times, Time):
+        ndim = in_times.squeeze().ndim
+        target_times = np.around((in_times - obs_times[0]).to(unit), decimals=decimals)
+        if ndim == 1:
+            unique_only = True
+        elif ndim == 2:
+            shape = in_times.shape
+            if 2 not in shape:
+                raise ValueError('If 2d list given must have shape (2, x) or (x, 2).')
+            if shape[0] == 2:
+                target_times = target_times.T
+                shape = shape[::-1]
+
+            target_times = target_times.flatten()
+        else:
+            raise ValueError('Only 1d or 2d time arrays are supported')
+
+    indices = abs(target_times[:, None] - relative_times[None, :]).argmin(axis=-1)
+    i1 = _closest_index_loop(target_times, relative_times)
+    i2 = _closest_index_broadcast(target_times, relative_times)
+    i3 = _closest_index_searchsorted(target_times, relative_times)
+    assert_equal(i1, i2)
+    assert_equal(i2, i3)
+    if shape:
+        indices = indices.reshape(shape)
+    if unique_only:
+        indices = np.unique(indices)
+    return indices
+
+
+def _closest_index_loop(a, b):
+    out = np.zeros(a.shape, int)
+    for i, val in enumerate(a):
+        out[i] = (np.abs(val-b)).argmin()
+    return out
+
+def _closest_index_searchsorted(a, b):
+    L = b.size
+    sidx_b = b.argsort()
+    sorted_b = b[sidx_b]
+    sorted_idx = np.searchsorted(sorted_b, a)
+    sorted_idx[sorted_idx == L] = L - 1
+    mask = (sorted_idx > 0) & ((np.abs(a - sorted_b[sorted_idx - 1]) <= np.abs(a - sorted_b[sorted_idx])))
+    return sidx_b[sorted_idx - mask]
+
+def _closest_index_broadcast(a, b):
+    return np.abs(a[:, None] - b[None, :]).argmin(axis=-1)

--- a/stixpy/utils/time.py
+++ b/stixpy/utils/time.py
@@ -15,6 +15,10 @@ def times_to_indices(in_times, obs_times, unit=u.ms, decimals=3):
         A target duration e.g `5*u.s` an array of `Time` if 2d
     obs_times : `astropy.units.Quantity`
 
+    unit : `astropy.units.Unit`
+
+    decimals : int
+
     Returns
     -------
     Array of indices
@@ -34,7 +38,7 @@ def times_to_indices(in_times, obs_times, unit=u.ms, decimals=3):
         else:
             target_times = relative_times[[0,-1]]
     elif isinstance(in_times, Time):
-        ndim = in_times.squeeze().ndim
+        ndim = in_times.ndim
         target_times = np.around((in_times - obs_times[0]).to(unit), decimals=decimals)
         if ndim == 1:
             unique_only = True
@@ -50,7 +54,7 @@ def times_to_indices(in_times, obs_times, unit=u.ms, decimals=3):
         else:
             raise ValueError('Only 1d or 2d time arrays are supported')
 
-    indices = abs(target_times[:, None] - relative_times[None, :]).argmin(axis=-1)
+    indices = np.abs(target_times[:, None] - relative_times[None, :]).argmin(axis=-1)
     i1 = _closest_index_loop(target_times, relative_times)
     i2 = _closest_index_broadcast(target_times, relative_times)
     i3 = _closest_index_searchsorted(target_times, relative_times)


### PR DESCRIPTION
This adds the ability to select the times by specifying a `Quantity` or  `Time` array addressing #11, #25 and closing #63. It adds a new `times` keyword to the `get_data`, `plot_pixels`, `plot_timeseries` and `plot_spectrogram` methods. The `times` keyword support 3 types of input a scalar quantity, 1d and 2d Time object (`astropy.time.Time`).

`times=20*u.s` will return the time bins closest to a 20s cadence
`times=Time([t1, t2, t3])` will return the times bin closes to t1, t2 and t3 where these are `astropy.time.Times`
`times=Time([[t1, t2], [t2, t3], [t3, t4]])` will sum the nearest times to those given e.g `t1` to `t2` (need not be contiguous)