### PR TITLE
Simple fix error in timerange logic order when querying for files

### DIFF
--- a/stixpy/net/client.py
+++ b/stixpy/net/client.py
@@ -101,7 +101,7 @@ class STIXClient(GenericClient):
                             file_tr = rowdict.pop('tr', None)
                             if file_tr is not None:
                                 # 4 cases full in, fully our start in or end in
-                                if file_tr.start >= tr.start and file_tr.end <= tr.end:
+                                if tr.start >= file_tr.start and tr.end <= file_tr.end:
                                     metalist.append(rowdict)
                                 elif tr.start <= file_tr.start and tr.end >= file_tr.end:
                                     metalist.append(rowdict)


### PR DESCRIPTION
There was a small error in the logic of returning files when for a given time, such that if a timerange was passed that the start was after the file start and the end was before the file end then Fido wouldnet return anything. 

This was due to the fact that the greater to symbols were the wrong way around. 

Before:
``` python
>>> Fido.search(a.Time("2021-12-24 10:02", "2021-12-24 10:15"), a.Instrument.stix, a.stix.DataProduct.sci_xray_cpd)
Results from 1 Provider:

0 Results from the STIXClient:
QueryResponse length=0

```

with this PR 
```python
>>> Fido.search(a.Time("2021-12-24 10:02", "2021-12-24 10:15"), a.Instrument.stix, a.stix.DataProduct.sci_xray_cpd)
Results from 1 Provider:

2 Results from the STIXClient:

       Start Time               End Time        Instrument ... Ver Request ID
----------------------- ----------------------- ---------- ... --- ----------
2021-12-24 10:01:11.000 2021-12-24 10:55:11.000       STIX ... V01 2112240039
2021-12-24 10:01:51.000 2021-12-24 10:31:09.000       STIX ... V01 2112240046
```
